### PR TITLE
Create MNIST & Transfer Learning with VGG-16 (Update).ipynb

### DIFF
--- a/MNIST & Transfer Learning with VGG-16 (Update).ipynb
+++ b/MNIST & Transfer Learning with VGG-16 (Update).ipynb
@@ -1,0 +1,139 @@
+#Lấy dữ liệu ảnh số [0,...,9] từ thư viện ảnh MNIST
+#Lớp được giữ lại: 1 - selected_class
+#Các Lớp khác (other): 0 - other
+#1. Lấy 20% dữ liệu mỗi phần trong lớp other
+#2. Resize ảnh đầu vào để sử dụng mô hình VGG16: 32x32
+#3. Load mô hình VGG16 đã được pre-trained với trọng số từ ImageNet, không bao gồm top layer
+#4. Đóng băng các lớp trong base model
+#5. Thêm các lớp fully connected mới
+#6. Tạo mô hình cuối cùng
+#7. Thiết lập callback để lưu trọng số tại epoch có val_accuracy tốt nhất
+#8. Huấn luyện mô hình với class_weight và callback ModelCheckpoint
+#9. Sau khi huấn luyện, load lại trọng số tốt nhất cho mô hình
+#10. Sử dụng mô hình đã huấn luyện để dự đoán trên tập kiểm tra
+#11. Duyệt qua tất cả các phần tử trong test set của lớp selected_class
+#12. Tính accuracy cho lớp selected_class
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras.datasets import mnist
+from tensorflow.keras.applications import VGG16
+from tensorflow.keras.layers import Dense, Flatten, Dropout
+from tensorflow.keras.models import Model
+from tensorflow.keras.optimizers import Adam
+from tensorflow.keras.callbacks import ModelCheckpoint
+from sklearn.utils.class_weight import compute_class_weight
+
+# Tải dữ liệu MNIST
+(train_images, train_labels), (test_images, test_labels) = mnist.load_data()
+
+# Lựa chọn các lớp bạn muốn giữ lại, ví dụ, lớp '1'
+selected_classes = [1]
+
+# Tạo nhãn mới: 1 cho lớp được giữ lại, 0 cho các lớp còn lại
+train_labels_new = np.where(np.isin(train_labels, selected_classes), 1, 0)
+test_labels_new = np.where(np.isin(test_labels, selected_classes), 1, 0)
+
+# Tách dữ liệu theo lớp
+selected_images = train_images[np.isin(train_labels, selected_classes)]
+selected_labels = train_labels_new[np.isin(train_labels, selected_classes)]
+
+other_images = []
+other_labels = []
+
+for label in range(10):
+    if label not in selected_classes:
+        class_images = train_images[train_labels == label]
+        class_labels = train_labels_new[train_labels == label]
+        random_indices = np.random.choice(class_images.shape[0], int(class_images.shape[0] * 0.5), replace=False)
+        other_images.append(class_images[random_indices])
+        other_labels.append(class_labels[random_indices])
+
+# Gộp dữ liệu từ các lớp khác thành lớp "other"
+other_images_reduced = np.concatenate(other_images, axis=0)
+other_labels_reduced = np.concatenate(other_labels, axis=0)
+
+# Kết hợp lại dữ liệu
+train_images_reduced = np.concatenate((selected_images, other_images_reduced), axis=0)
+train_labels_reduced = np.concatenate((selected_labels, other_labels_reduced), axis=0)
+
+# Chuẩn hóa dữ liệu
+train_images_reduced = train_images_reduced / 255.0
+test_images = test_images / 255.0
+
+# Chuyển đổi dữ liệu thành định dạng cần thiết cho VGG16 (3 kênh) và thay đổi kích thước
+train_images_reduced = np.stack([train_images_reduced] * 3, axis=-1)
+test_images = np.stack([test_images] * 3, axis=-1)
+
+train_images_resized = tf.image.resize(train_images_reduced, [32, 32])
+test_images_resized = tf.image.resize(test_images, [32, 32])
+
+# Tính trọng số lớp
+class_weights = compute_class_weight('balanced', classes=np.unique(train_labels_reduced), y=train_labels_reduced)
+class_weights_dict = dict(enumerate(class_weights))
+
+
+# Tăng trọng số của lớp thiểu số để tăng trọng số của lớp được giữ lại
+class_weights_dict[1] *= 3  # Điều chỉnh hệ số này theo nhu cầu
+
+
+# Load mô hình VGG16 đã được pre-trained với trọng số từ ImageNet, không bao gồm top layer
+base_model = VGG16(weights='imagenet', include_top=False, input_shape=(32, 32, 3))
+
+# Đóng băng các lớp trong base model
+for layer in base_model.layers:
+    layer.trainable = False
+
+# Thêm các lớp fully connected mới
+x = Flatten()(base_model.output)
+x = Dense(256, activation='relu')(x)
+x = Dropout(0.5)(x)
+x = Dense(128, activation='relu')(x)
+x = Dropout(0.5)(x)
+predictions = Dense(1, activation='sigmoid')(x)
+
+# Tạo mô hình cuối cùng
+model = Model(inputs=base_model.input, outputs=predictions)
+
+# Biên dịch mô hình với learning rate thấp hơn để cải thiện hội tụ
+model.compile(optimizer=Adam(learning_rate=0.0001),
+              loss='binary_crossentropy',
+              metrics=['accuracy'])
+
+# Thiết lập callback để lưu trọng số tại epoch có val_accuracy tốt nhất
+checkpoint = ModelCheckpoint('best_model_weights.keras',
+                             monitor='val_accuracy',
+                             save_best_only=True,
+                             mode='max',
+                             verbose=1)
+
+# Huấn luyện mô hình với class_weight và callback ModelCheckpoint
+model.fit(train_images_resized, train_labels_reduced,
+          epochs=30, batch_size=32,
+          validation_data=(test_images_resized, test_labels_new),
+          class_weight=class_weights_dict,
+          callbacks=[checkpoint])
+
+# Sau khi huấn luyện, load lại trọng số tốt nhất cho mô hình
+model.load_weights('best_model_weights.keras')
+
+# Đánh giá mô hình với trọng số tốt nhất
+test_loss, test_accuracy = model.evaluate(test_images_resized, test_labels_new)
+print(f'Best Test accuracy: {test_accuracy * 100:.2f}%')
+
+# Sử dụng mô hình đã huấn luyện để dự đoán trên tập kiểm tra
+predictions = model.predict(test_images_resized)
+
+# Duyệt qua tất cả các phần tử trong test set của lớp selected_class
+correct_predictions = 0
+selected_class_indices = np.where(np.isin(test_labels, selected_classes))[0]
+
+for idx in selected_class_indices:
+    if predictions[idx] > 0.5:
+        correct_predictions += 1
+
+# Tổng số phần tử trong lớp selected_class trong tập kiểm tra
+total_selected_class = len(selected_class_indices)
+
+# Tính accuracy cho lớp selected_class
+selected_class_accuracy = correct_predictions / total_selected_class
+print(f'Accuracy for selected_class (1): {selected_class_accuracy * 100:.2f}%')


### PR DESCRIPTION
#Lấy dữ liệu ảnh số [0,...,9] từ thư viện ảnh MNIST 
#Lớp được giữ lại: 1 - selected_class
#Các Lớp khác (other): 0 - other
#1. Lấy 20% dữ liệu mỗi phần trong lớp other
#2. Resize ảnh đầu vào để sử dụng mô hình VGG16: 32x32 
#3. Load mô hình VGG16 đã được pre-trained với trọng số từ ImageNet, không bao gồm top layer 
#4. Đóng băng các lớp trong base model
#5. Thêm các lớp fully connected mới
#6. Tạo mô hình cuối cùng
#7. Thiết lập callback để lưu trọng số tại epoch có val_accuracy tốt nhất 
#8. Huấn luyện mô hình với class_weight và callback ModelCheckpoint 
#9. Sau khi huấn luyện, load lại trọng số tốt nhất cho mô hình 
#10. Sử dụng mô hình đã huấn luyện để dự đoán trên tập kiểm tra 
#11. Duyệt qua tất cả các phần tử trong test set của lớp selected_class 
#12. Tính accuracy cho lớp selected_class